### PR TITLE
Setup relationships between element types

### DIFF
--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -8,48 +8,47 @@ use Illuminate\Support\Facades\Schema;
 return new class () extends Migration {
     public function up(): void
     {
-        DB::transaction(function () {
-            Schema::table('types', function (Blueprint $table) {
-                $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
+        try {
+            DB::transaction(function () {
+                Schema::table('types', function (Blueprint $table) {
+                    $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
+                });
+
+                $types = DB::table('types')->get();
+                $parents = $types->whereIn('name', ['metal', 'nonmetal', 'metalloid']);
+                $children = $types->whereNotIn('name', $parents);
+                $nonMetals = $types->whereIn('name', ['noble-gas', 'halogen']);
+                $metals = $children->whereNotIn('name', ['metal', 'nonmetal', 'metalloid', 'noble-gas', 'halogen']);
+
+                $nonMetals = $nonMetals->map(function ($nonMetal) use ($parents) {
+                    $nonMetalParent = $parents->where('name', '=', 'nonmetal')->values();
+                    $nonMetal->parent_id = $nonMetalParent[0]->id;
+
+                    return (array)$nonMetal;
+                });
+
+                $metals = $metals->map(function ($metal) use ($parents) {
+                    $metalParent = $parents->where('name', '=', 'metal')->values();
+                    $metal->parent_id = $metalParent[0]->id;
+
+                    return (array)$metal;
+                });
+
+                DB::table('types')->upsert($nonMetals->toArray(), ['id'], ['parent_id']);
+                DB::table('types')->upsert($metals->toArray(), ['id'], ['parent_id']);
+
             });
+        } catch (Exception $exception) {
+            throw new Error("Force rollback with $exception");
 
-            $types = DB::table('types')->get();
-            $parents = $types->whereIn('name', ['metal', 'nonmetal', 'metalloid']);
-            $children = $types->whereNotIn('name', $parents);
-            $nonMetals = $types->whereIn('name', ['noble-gas', 'halogen']);
-            $metals = $children->whereNotIn('name', $nonMetals);
-
-//            TODO: standardize this: either each or map
-            $nonMetals = $nonMetals->each(function ($nonmetal) use ($parents) {
-                $nonmetalParent = $parents->where('name', '=', 'nonmetal');
-                $nonmetal->parent_id = $nonmetalParent[0]->id;
-            })->map(fn($item) => (array)$item);
-
-            $metals = $metals->map(function ($metal) use ($parents) {
-                $metalParent = $parents->where('name', '=', 'metal')->values();
-                $metal->parent_id = $metalParent[0]->id;
-
-                return (array) $metal;
-            });
-
-
-//            TODO: Fix this
-//            TODO: potentially metal is not filtered out properly, and is updating everything to parent id 7
-//            DB::table('types')->whereIn('id', $nonMetals->pluck("id") )->update([
-//                "parent_id" => $nonMetals[0]->parent_id
-//            ]);
-//            dd($nonMetals->toArray());
-            DB::table('types')->upsert($nonMetals->toArray(), ['id'], ['parent_id']);
-            DB::table('types')->upsert($metals->toArray(), ['id', 'parent_id'], ['parent_id']);
-            //throw new Error("Force rollback");
-        });
+        }
     }
 
     public function down(): void
     {
         Schema::table('types', function (Blueprint $table) {
+            $table->dropForeign('types_parent_id_foreign');
             $table->dropColumn('parent_id');
-            //$table->dropForeign('types_parent_id_foreign');
         });
     }
 };

--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table('types', function (Blueprint $table) {
+                $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
+            });
+
+            $types = DB::table('types')->get();
+
+            $children = $types->filter(function ($type) {
+                return $type['name'] !== 'metal' || $type['name'] !== 'nonmetal' || $type['name'] !== 'metalloid';
+            });
+
+            // TODO: we stopped here
+            // TODO: highlight the nonmetal as a subgroup only as part of the overall nonmetal parent group on parent select
+            $nonMetals = collect(['noble-gas', 'halogen']);
+            $metalChildren = $children->filter(function ($child) {
+                // return all types that are metal types
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('types', function (Blueprint $table) {
+            $table->dropForeign('parent_id_types_index'); // TODO: Double check the naming of this when the column is created.
+        });
+    }
+};

--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -14,24 +14,32 @@ return new class () extends Migration {
             });
 
             $types = DB::table('types')->get();
+            $parents = $types->whereIn('name', ['metal', 'nonmetal', 'metalloid']);
+            $children = $types->whereNotIn('name', $parents);
+            $nonMetals = $types->whereIn('name', ['noble-gas', 'halogen']);
+            $metals = $children->whereNotIn('name', $nonMetals);
 
-            $children = $types->filter(function ($type) {
-                return $type['name'] !== 'metal' || $type['name'] !== 'nonmetal' || $type['name'] !== 'metalloid';
+            $nonMetals->each(function ($nonmetal) use ($parents) {
+                $nonmetalParent = $parents->where('name', '=', 'nonmetal');
+                $nonmetal->parent_id = $nonmetalParent[0]->id;
             });
 
-            // TODO: we stopped here
-            // TODO: highlight the nonmetal as a subgroup only as part of the overall nonmetal parent group on parent select
-            $nonMetals = collect(['noble-gas', 'halogen']);
-            $metalChildren = $children->filter(function ($child) {
-                // return all types that are metal types
+            // TODO: this is indexed weirdly
+            // TODO: fix indexing
+            $metals->each(function ($metal) use ($parents) {
+                $metalParent = $parents->where('name', '=', 'metal');
+                dd($metalParent[6]);
+                $metal->parent_id = $metalParent->id;
             });
+
+            // TODO: commit updated types to the database
         });
     }
 
     public function down(): void
     {
         Schema::table('types', function (Blueprint $table) {
-            $table->dropForeign('parent_id_types_index'); // TODO: Double check the naming of this when the column is created.
+//            $table->dropForeign('parent_id_types_index'); // TODO: Double check the naming of this when the column is created.
         });
     }
 };

--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -19,27 +19,37 @@ return new class () extends Migration {
             $nonMetals = $types->whereIn('name', ['noble-gas', 'halogen']);
             $metals = $children->whereNotIn('name', $nonMetals);
 
-            $nonMetals->each(function ($nonmetal) use ($parents) {
+//            TODO: standardize this: either each or map
+            $nonMetals = $nonMetals->each(function ($nonmetal) use ($parents) {
                 $nonmetalParent = $parents->where('name', '=', 'nonmetal');
                 $nonmetal->parent_id = $nonmetalParent[0]->id;
+            })->map(fn($item) => (array)$item);
+
+            $metals = $metals->map(function ($metal) use ($parents) {
+                $metalParent = $parents->where('name', '=', 'metal')->values();
+                $metal->parent_id = $metalParent[0]->id;
+
+                return (array) $metal;
             });
 
-            // TODO: this is indexed weirdly
-            // TODO: fix indexing
-            $metals->each(function ($metal) use ($parents) {
-                $metalParent = $parents->where('name', '=', 'metal');
-                dd($metalParent[6]);
-                $metal->parent_id = $metalParent->id;
-            });
 
-            // TODO: commit updated types to the database
+//            TODO: Fix this
+//            TODO: potentially metal is not filtered out properly, and is updating everything to parent id 7
+//            DB::table('types')->whereIn('id', $nonMetals->pluck("id") )->update([
+//                "parent_id" => $nonMetals[0]->parent_id
+//            ]);
+//            dd($nonMetals->toArray());
+            DB::table('types')->upsert($nonMetals->toArray(), ['id'], ['parent_id']);
+            DB::table('types')->upsert($metals->toArray(), ['id', 'parent_id'], ['parent_id']);
+            //throw new Error("Force rollback");
         });
     }
 
     public function down(): void
     {
         Schema::table('types', function (Blueprint $table) {
-//            $table->dropForeign('parent_id_types_index'); // TODO: Double check the naming of this when the column is created.
+            $table->dropColumn('parent_id');
+            //$table->dropForeign('types_parent_id_foreign');
         });
     }
 };

--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -8,43 +8,33 @@ use Illuminate\Support\Facades\Schema;
 return new class () extends Migration {
     public function up(): void
     {
-        try {
-            DB::transaction(function () {
-                Schema::table('types', function (Blueprint $table) {
-                    $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
-                });
-
-                $parentsNames = ['metal', 'nonmetal', 'metalloid'];
-                $nonMetalChildrenNames = ['noble-gas', 'halogen'];
-
-                $types = DB::table('types')->get();
-                $parents = $types->whereIn('name', $parentsNames);
-                $children = $types->whereNotIn('name', $parents);
-                $nonMetals = $types->whereIn('name', $nonMetalChildrenNames);
-                $metals = $children->whereNotIn('name', array_merge($parentsNames, $nonMetalChildrenNames));
-
-                $nonMetals = $nonMetals->map(function ($nonMetal) use ($parents) {
-                    $nonMetalParent = $parents->where('name', '=', 'nonmetal')->values();
-                    $nonMetal->parent_id = $nonMetalParent[0]->id;
-
-                    return (array)$nonMetal;
-                });
-
-                $metals = $metals->map(function ($metal) use ($parents) {
-                    $metalParent = $parents->where('name', '=', 'metal')->values();
-                    $metal->parent_id = $metalParent[0]->id;
-
-                    return (array)$metal;
-                });
-
-                DB::table('types')->upsert($nonMetals->toArray(), ['id'], ['parent_id']);
-                DB::table('types')->upsert($metals->toArray(), ['id'], ['parent_id']);
-
+        DB::transaction(function () {
+            Schema::table('types', function (Blueprint $table) {
+                $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
             });
-        } catch (Exception $exception) {
-            throw new Error("Force rollback with $exception");
 
-        }
+            $parentsNames = ['metal', 'nonmetal', 'metalloid'];
+            $nonMetalChildrenNames = ['noble-gas', 'halogen'];
+
+            $types = DB::table('types')->get();
+            [$metal, $_, $nonmetal] = $types->whereIn('name', $parentsNames)->sortBy('name')->values()->toArray();
+            $children = $types->whereNotIn('name', $parentsNames);
+            $nonMetalKids = $types->whereIn('name', $nonMetalChildrenNames);
+            $metalKids = $children->whereNotIn('name', array_merge($parentsNames, $nonMetalChildrenNames));
+
+            $nonMetalKids = $nonMetalKids->map(function ($nonMetal) use ($nonmetal) {
+                $nonMetal->parent_id = $nonmetal->id;
+                return (array)$nonMetal;
+            });
+
+            $metalKids = $metalKids->map(function ($metalKid) use ($metal) {
+                $metalKid->parent_id = $metal->id;
+                return (array)$metalKid;
+            });
+
+            DB::table('types')->upsert($nonMetalKids->toArray(), ['id'], ['parent_id']);
+            DB::table('types')->upsert($metalKids->toArray(), ['id'], ['parent_id']);
+        });
     }
 
     public function down(): void

--- a/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
+++ b/database/migrations/2025_12_02_211934_add_relations_to_types_table.php
@@ -14,11 +14,14 @@ return new class () extends Migration {
                     $table->foreignId('parent_id')->nullable()->default(null)->references('id')->on('types');
                 });
 
+                $parentsNames = ['metal', 'nonmetal', 'metalloid'];
+                $nonMetalChildrenNames = ['noble-gas', 'halogen'];
+
                 $types = DB::table('types')->get();
-                $parents = $types->whereIn('name', ['metal', 'nonmetal', 'metalloid']);
+                $parents = $types->whereIn('name', $parentsNames);
                 $children = $types->whereNotIn('name', $parents);
-                $nonMetals = $types->whereIn('name', ['noble-gas', 'halogen']);
-                $metals = $children->whereNotIn('name', ['metal', 'nonmetal', 'metalloid', 'noble-gas', 'halogen']);
+                $nonMetals = $types->whereIn('name', $nonMetalChildrenNames);
+                $metals = $children->whereNotIn('name', array_merge($parentsNames, $nonMetalChildrenNames));
 
                 $nonMetals = $nonMetals->map(function ($nonMetal) use ($parents) {
                     $nonMetalParent = $parents->where('name', '=', 'nonmetal')->values();


### PR DESCRIPTION
This PR creates a migration to update the `types` table with parental relationships to other types (i.e., noble-gas is a child of non-metal type). 

## NOTE
[Another ticket](https://app.clickup.com/t/86adww2tf) has been created for the next stage of the work that will create a new endpoint, respective controller and add test coverage. This PR was scoped only to the migration work. 